### PR TITLE
[fix] change to the right sanbox url for YXBJ developer from China

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -62,7 +62,9 @@ class Client {
     this.china = !!options.china;
     this.token = options.token;
     let defaultServiceHost;
-    if (this.sandbox) {
+    if (this.sandbox && this.china) {
+      defaultServiceHost = 'sandbox.yinxiang.com';
+    } else if (this.sandbox) {
       defaultServiceHost = 'sandbox.evernote.com';
     } else if (this.china) {
       defaultServiceHost = 'app.yinxiang.com';


### PR DESCRIPTION
Many developers with YXBJ(印象笔记) got 401 error with the dismatched sanbox url--sandbox.evernote.com